### PR TITLE
WALDO-45 -- UI: Create the version history placeholder page

### DIFF
--- a/resources/views/pages/about/version-history.blade.php
+++ b/resources/views/pages/about/version-history.blade.php
@@ -1,0 +1,86 @@
+<!DOCTYPE HTML>
+<html class="no-js" lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <title>Waldo Web Service</title>
+    <meta name="description" content="A Web Service that delivers information on CSUN rooms">
+    <link rel="icon" href="//www.csun.edu/sites/default/themes/csun/favicon.ico" type="image/x-icon">
+    <script src="//use.typekit.net/gfb2mjm.js"></script>
+    <script>try{Typekit.load();}catch(e){}</script>
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic,700,700italic,800,800italic">
+    <link rel="stylesheet" href="{{ url('css/metaphor.css') }}">
+    <link rel="stylesheet" href="{{ url('css/tomorrow.css.min') }}">
+</head>
+<body>
+<div class="section section--sm">
+    <div class="container type--center">
+        <h1 class="giga type--thin">Waldo Web Service</h1>
+        <h3 class="h1 type--thin type--gray">Delivering CSUN Room Location Information</h3>
+    </div>
+</div>
+
+<div class="section" style="min-height: calc(100vh - 130px);">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3">
+                <a class="header--sm" href="{{ url('/') }}"><strong>DOCUMENTATION</strong></a>
+                <ul class="nav">
+                    <li class="nav__item"><a class="nav__link" href="{{ url('/#introduction')}}">Introduction</a></li>
+                    <li class="nav__item"><a class="nav__link" href="{{ url('/#getting-started')}}">Getting Started</a></li>
+                    <li class="nav__item"><a class="nav__link" href="{{ url('/#collections')}}">Collections</a></li>
+                    <li class="nav__item"><a class="nav__link" href="{{ url('/#subcollections')}}">Subcollections</a></li>
+                </ul>
+                <a class="header--sm" href="{{ url('/about/version-history') }}"><strong>VERSION HISTORY</strong></a>
+            </div>
+
+            <div class="col-md-9">
+                <h2 class="type--header type--thin">Version History</h2>
+                <h2>Waldo 1.0 <small>Release Date: 10/09/17</small></h2>
+                <p>
+                    <strong>New Features:</strong>
+                <ol>
+                    <li>Ability to retrieve room location information.</li>
+                </ol>
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="metalab-footer">
+    <div class="metalab-wrapper">
+        <div class="container">
+            <div class="row">
+                <div class="col-sm-6">
+                    <div class="metalab-branding">
+                        <img src="//www.csun.edu/faculty/imgs/meta-logo-horz.png" alt="CSUN META Lab Logo">
+                        <ul class="list--unstyled">
+                            <li><a href="http://metalab.csun.edu">metalab.csun.edu</a></li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="col-sm-6">
+                    <ul class="list--unstyled metalab-tagline">
+                        <li>Explore. Learn. Go Beyond.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<!--
+  __  __   ___   _____     _
+ |  \/  | | __| |_   _|   /_\       Explore Learn Go Beyond
+ | |\/| | | _|    | |    / _ \      https://www.metalab.csun.edu/
+ |_|  |_| |___|   |_|   /_/ \_\
+    _       _        _     ___
+  _| |_    | |      /_\   | _ )
+ |_   _|   | |__   / _ \  | _ \
+   |_|     |____| /_/ \_\ |___/
+-->
+</body>
+</html>

--- a/resources/views/pages/index.blade.php
+++ b/resources/views/pages/index.blade.php
@@ -55,7 +55,6 @@
     "latitude": 34.24141145,
     "longitude": -118.529299945
   }
-}
 }</code></pre>
                 <br>
                 <h2 id="getting-started" class="type--header type--thin">Getting Started</h2>

--- a/resources/views/pages/index.blade.php
+++ b/resources/views/pages/index.blade.php
@@ -18,7 +18,7 @@
 <div class="section section--sm">
     <div class="container type--center">
         <h1 class="giga type--thin">Waldo Web Service</h1>
-        <h3 class="h1 type--thin type--gray">Delivering CSUN Room information</h3>
+        <h3 class="h1 type--thin type--gray">Delivering CSUN Room Location Information</h3>
     </div>
 </div>
 
@@ -26,24 +26,25 @@
     <div class="container">
         <div class="row">
             <div class="col-md-3">
-                <p class="header--sm"><strong>Documentation</strong></p>
+                <a class="header--sm" href="{{ url('/') }}"><strong>DOCUMENTATION</strong></a>
                 <ul class="nav">
                     <li class="nav__item"><a class="nav__link" href="#introduction">Introduction</a></li>
                     <li class="nav__item"><a class="nav__link" href="#getting-started">Getting Started</a></li>
                     <li class="nav__item"><a class="nav__link" href="#collections">Collections</a></li>
                     <li class="nav__item"><a class="nav__link" href="#subcollections">Subcollections</a></li>
                 </ul>
+                <a class="header--sm" href="{{ url('/about/version-history') }}"><strong>VERSION HISTORY</strong></a>
             </div>
 
             <div class="col-md-9">
                 <h2 id="introduction" class="type--header type--thin">Introduction</h2>
-                <p>The Waldo web service retrieves CSUN room location information.</p>
-                    {{--This information is derived from the Research and Graduate Studies and faculty submited information --}}
-                    {{--using <a href="">Scholarships</a>. The web service provides a gateway to access the information via --}}
-                    {{--a REST-ful API. The information is retrieved by creating a specific URI and giving values to filter --}}
-                    {{--the data. The information that is returned is a JSON object that contains a set of interest or --}}
-                    {{--badges attached to a particular member; the format of the JSON object is as follows:</p>--}}
-
+                <p>
+                    The information is derived from the Facilities Database maintained by Admin and Finance IT.
+                    The web service provides a gateway via a REST-ful API. The information is retrieved by
+                    creating a specific URI and giving values to filter the data. The information that is
+                    returned is a JSON object that contains room location information to a particular room;
+                    the format of the JSON object is as follows:
+                </p>
         <pre class="prettyprint"><code>{
   "status": "200",
   "success": "true",
@@ -54,6 +55,7 @@
     "latitude": 34.24141145,
     "longitude": -118.529299945
   }
+}
 }</code></pre>
                 <br>
                 <h2 id="getting-started" class="type--header type--thin">Getting Started</h2>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,10 @@
 
 $app->get('/', 'RoomsController@index');
 
+$app->get('/about/version-history', function() {
+    return view('pages.about.version-history');
+});
+
 $app->group(['prefix' => 'api/1.0'], function() use ($app) {
     $app->get('/rooms', 'RoomsController@handleRequest');
 });


### PR DESCRIPTION
# Summary
This task was to create a version history page. This task accomplishes that.

# To Test
Check to see that you can reach `/about/version-history` as well as reaching the version history page by clicking the Version History header and navigating back to the landing page.