### PR TITLE
WALDO-51 -- ENG: The All rooms JSON is not consistent

### DIFF
--- a/app/Http/Controllers/RoomsController.php
+++ b/app/Http/Controllers/RoomsController.php
@@ -41,9 +41,17 @@ class RoomsController extends Controller
      */
     public function getAllRooms()
     {
-        $roomData = Room::all();
+        $allRooms = Room::all();
+        $allRooms = $allRooms->map(function($roomDetail) {
+            return [
+                'room_number'   => $roomDetail->room,
+                'building_name' => $roomDetail->building_name,
+                'latitude'      => $roomDetail->latitude,
+                'longitude'     => $roomDetail->longitude
+                ];
+        });
         $header = buildResponseHeaderArray(200, 'true');
-        return appendRoomDataToResponseHeader($header, 'rooms', $roomData);
+        return appendRoomDataToResponseHeader($header, 'rooms', $allRooms);
     }
 
     /**

--- a/tests/RoomsControllerTest.php
+++ b/tests/RoomsControllerTest.php
@@ -32,6 +32,11 @@ class RoomsControllerTest extends TestCase
         $this->assertEquals($data['status'],200);
         $this->assertEquals($data['success'],'true');
         $this->assertEquals($data['collection'],'rooms');
+        $this->assertEquals($data['count'],1);
+        $this->assertArrayHasKey('room_number', $data['rooms'][0]);
+        $this->assertArrayHasKey('building_name', $data['rooms'][0]);
+        $this->assertArrayHasKey('latitude', $data['rooms'][0]);
+        $this->assertArrayHasKey('longitude', $data['rooms'][0]);
         $this->assertEquals($data['rooms'][0]['room_number'],$this->roomID);
         $this->assertEquals($data['rooms'][0]['building_name'],'Jacaranda Hall');
         $this->assertEquals($data['rooms'][0]['latitude'],$this->lat);
@@ -49,6 +54,10 @@ class RoomsControllerTest extends TestCase
         $this->assertEquals($data['success'],'true');
         $this->assertEquals($data['collection'],'rooms');
         $this->assertEquals(count($data['rooms']),5944);
+        $this->assertArrayHasKey('room_number', $data['rooms'][0]);
+        $this->assertArrayHasKey('building_name', $data['rooms'][0]);
+        $this->assertArrayHasKey('latitude', $data['rooms'][0]);
+        $this->assertArrayHasKey('longitude', $data['rooms'][0]);
     }
     public function testHandleRequest_returns_room(){
         $data = $this->call('GET', 'api/1.0/rooms?room=' . $this->roomID);


### PR DESCRIPTION
# Summary
The JSON from the all rooms end-point does not follow the JSON example given on the landing page of waldo. This task addresses that

# To Test
Visit both `/rooms` and `/rooms?room=JD221` and notice that now the JSON structure is identical.