### PR TITLE
Calculate unknown lat/long without use of a web service

### DIFF
--- a/app/Classes/CoordinatesHelper.php
+++ b/app/Classes/CoordinatesHelper.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Classes;
+
+class CoordinatesHelper
+{
+	/**
+	 * Constant describing the conversion metric from kilometers to meters.
+	 *
+	 * @var float
+	 */
+	const KILOMETERS_TO_METERS = 1000.0;
+
+	/**
+	 * Constant describing the conversion metric from meters to kilometers.
+	 *
+	 * @var float
+	 */
+	const METERS_TO_KILOMETERS = 0.001;
+
+	/**
+	 * Constant describing the conversion metric from meters to feet.
+	 *
+	 * @var float
+	 */
+	const METERS_TO_FEET = 3.28084;
+
+	/**
+	 * Constant describing the conversion metric from feet to meters.
+	 *
+	 * @var float
+	 */
+	const FEET_TO_METERS = 0.3048;
+
+	/**
+	 * Constant describing the approximate radius of the Earth in kilometers.
+	 * This is used in lat/long calculations due to the Earth's curviture.
+	 *
+	 * @var float
+	 */
+	const EARTH_RADIUS_KILOMETERS = 6371.0;
+}

--- a/app/Classes/StatePlaneMapping.php
+++ b/app/Classes/StatePlaneMapping.php
@@ -2,7 +2,12 @@
 
 namespace App\Classes;
 
-class CoordinatesHelper
+/**
+ * This class exists to perform well-known calculations for the State Plane
+ * Coordinate system. Its primary use is to convert X/Y relative coordinates
+ * in a given zone to absolute latitude/longitude coordinates for mapping.
+ */
+class StatePlaneMapping
 {
 	/**
 	 * Constant describing the conversion metric from kilometers to meters.
@@ -39,4 +44,18 @@ class CoordinatesHelper
 	 * @var float
 	 */
 	const EARTH_RADIUS_KILOMETERS = 6371.0;
+
+	/**
+	 * Constant describing source units as feet for calculations.
+	 *
+	 * @var string
+	 */
+	const UNITS_FEET = "feet";
+
+	/**
+	 * Constant describing source units as meters for calculations.
+	 *
+	 * @var string
+	 */
+	const UNITS_METERS = "meters";
 }

--- a/app/Classes/StatePlaneMapping.php
+++ b/app/Classes/StatePlaneMapping.php
@@ -86,7 +86,7 @@ class StatePlaneMapping
 
 		// 3. Calculate the lat/long from our reversed distance
 		return self::latLongFromDistance(
-			$known_lat, $known_lon, $dx_from_plate, $dy_from_plate
+			$known_lat, $known_lon, $dx_from_plate, $dy_from_plate, "plate"
 		);
 	}
 
@@ -106,13 +106,23 @@ class StatePlaneMapping
 	 *
 	 * @see https://stackoverflow.com/a/7478827
 	 */
-	private static function latLongFromDistance($lat, $lon, $easting, $northing) {
+	private static function latLongFromDistance($lat, $lon, $easting, $northing, $type="point") {
 		$new_lat = $lat + ($northing / (self::EARTH_RADIUS_KILOMETERS * self::KILOMETERS_TO_METERS)) *
 			(180.0 / M_PI);
 
+		if($type == "point") {
+			// non-plate calculation needs the original latitude parameter
+			$latval = $lat;
+		}
+		else
+		{
+			// plate calculation needs the newly-calculated latitude
+			$latval = $new_lat;
+		}
+
 		$new_long = $lon + ($northing / (self::EARTH_RADIUS_KILOMETERS * self::KILOMETERS_TO_METERS)) *
 			(180.0 / M_PI) /
-			cos($new_lat * (M_PI/180.0));
+			cos($latval * (M_PI/180.0));
 
 		return [
 			'lat' => $new_lat,

--- a/app/Classes/StatePlaneMapping.php
+++ b/app/Classes/StatePlaneMapping.php
@@ -58,4 +58,33 @@ class StatePlaneMapping
 	 * @var string
 	 */
 	const UNITS_METERS = "meters";
+
+	/**
+	 * Calculates and returns the number of meters per degree of longtitude. This
+	 * can be used in calculations regarding northing.
+	 *
+	 * @param float $longitude The longitude for which to calculate the meters
+	 * @return float
+	 *
+	 * @see https://stackoverflow.com/a/7478827
+	 */
+	public static function metersPerLongitudeDegree($longitude) {
+		return ((2.0 * M_PI) / 360.0) *
+			self::EARTH_RADIUS_KILOMETERS * self::KILOMETERS_TO_METERS *
+			cos($longitude);
+	}
+
+	/**
+	 * Calculates and returns the number of meters per degree of latitude. This
+	 * can be used in calculations regarding easting.
+	 *
+	 * @param float $latitude The latitude for which to calculate the meters
+	 * @return float
+	 *
+	 * @see https://stackoverflow.com/a/7478827
+	 */
+	public static function metersPerLatitudeDegree($latitude) {
+		return ((2.0 * M_PI) / 360.0) *
+			self::EARTH_RADIUS_KILOMETERS * self::KILOMETERS_TO_METERS;
+	}
 }

--- a/app/Classes/StatePlaneMapping.php
+++ b/app/Classes/StatePlaneMapping.php
@@ -67,57 +67,51 @@ class StatePlaneMapping
 	 *
 	 * @param float $plate_lat The latitude of the plate
 	 * @param float $plate_lon The longitude of the plate
-	 * @param float $dx_from_plate The distance away from the plate on the X axis
 	 * @param float $dy_from_plate The distance away from the plate on the Y axis
 	 * @param string $units Can be either "meters" or "feet" and represents the units
-	 * used for the $dx_from_plate and $dy_from_plate parameters
+	 * used for the $dy_from_plate parameter
 	 * 
 	 * @return array
 	 */
 	public static function findLatLongFromPlateDistance($plate_lat, $plate_lon,
-		$dx_from_plate, $dy_from_plate, $units="meters") {
+		$dy_from_plate, $units="meters") {
 		// check the units and perform conversions if necessary
 		if($units == self::UNITS_FEET) {
-			$dx_from_plate = $dx_from_plate * self::FEET_TO_METERS;
 			$dy_from_plate = $dy_from_plate * self::FEET_TO_METERS;
 		}
 
 		return self::latLongFromDistance(
-			$plate_lat, $plate_lon, $dx_from_plate, $dy_from_plate
+			$plate_lat, $plate_lon, $dy_from_plate
 		);
 	}
 
 	/**
 	 * Calculates and returns the origin of the plate based on a known
-	 * latitude and longitude as well as an X distance (easting) and a Y
-	 * distance (northing) from that plate.
+	 * latitude and longitude as well as the Y distance (northing) from that plate.
 	 * The return value is an array with a "lat" key and a "lon" key.
 	 *
 	 * @param float $known_lat The known latitude of a point
 	 * @param float $known_lon The known longitude of a point
-	 * @param float $dx_from_plate The distance to the point on the X axis from the plate
 	 * @param float $dy_from_plate The distance to the point on the Y axis from the plate
 	 * @param string $units Can be either "meters" or "feet" and represents the units
-	 * used for the $dx_from_plate and $dy_from_plate parameters
+	 * used for the $dy_from_plate parameter
 	 * 
 	 * @return array
 	 */
 	public static function findPlateOriginFromCoordDistance($known_lat, $known_lon,
-		$dx_from_plate, $dy_from_plate, $units="meters") {
+		$dy_from_plate, $units="meters") {
 		
 		// 1. Negate the distance from the plate so we can work backwards
-		$dx_from_plate = -$dx_from_plate;
 		$dy_from_plate = -$dy_from_plate;
 
 		// 2. Perform any necessary unit conversions
 		if($units == self::UNITS_FEET) {
-			$dx_from_plate = $dx_from_plate * self::FEET_TO_METERS;
 			$dy_from_plate = $dy_from_plate * self::FEET_TO_METERS;
 		}
 
 		// 3. Calculate the lat/long from our reversed distance
 		return self::latLongFromDistance(
-			$known_lat, $known_lon, $dx_from_plate, $dy_from_plate, "plate"
+			$known_lat, $known_lon, $dy_from_plate, "plate"
 		);
 	}
 
@@ -131,6 +125,8 @@ class StatePlaneMapping
 	 * @param float $lat The existing latitude to use for the calculation
 	 * @param float $lon The existing longitude to use for the calculation
 	 * @param float $northing The Y distance to add to the longitude
+	 * @param string $type "point" to calculate regular point; "plate" to calculate
+	 * the plate coordinates
 	 *
 	 * @return array
 	 *
@@ -138,9 +134,13 @@ class StatePlaneMapping
 	 *
 	 * The longitude formula given in that StackOverflow answer is slightly
 	 * wrong; dx should really be dy (northing) and latitude should really
-	 * be the newly-calculated value of new_longitude.
+	 * be the newly-calculated value of new_longitude. In addition, the calculation
+	 * of the longitude needs to be done differently based upon whether we are
+	 * working backwards to calculate the plate coordinates from a known position
+	 * or using the plate coordinates to calculate unknown coordinates using a
+	 * distance on the Y axis.
 	 */
-	private static function latLongFromDistance($lat, $lon, $easting, $northing, $type="point") {
+	private static function latLongFromDistance($lat, $lon, $northing, $type="point") {
 		$new_lat = $lat + ($northing / (self::EARTH_RADIUS_KILOMETERS * self::KILOMETERS_TO_METERS)) *
 			(180.0 / M_PI);
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "laravel/lumen-framework": "5.4.*",
         "vlucas/phpdotenv": "~2.2",
         "csun-metalab/lumen-proxypass": "^1.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~6.0",
+        "proj4php/proj4php": "^2.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "classmap": [
             "tests/",
             "database/",
+            "app/Classes",
             "app/Models"
         ]
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e6ff3db9d0921a0a420f8e60979197c7",
+    "content-hash": "a54b2f2833a03c137f77af9a5344a2c0",
     "packages": [
         {
             "name": "csun-metalab/lumen-proxypass",
@@ -1705,6 +1705,66 @@
                 "random"
             ],
             "time": "2017-09-27T21:40:39+00:00"
+        },
+        {
+            "name": "proj4php/proj4php",
+            "version": "2.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/proj4php/proj4php.git",
+                "reference": "bfbac92300cfdca7606f19afb3f401431320e5ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/proj4php/proj4php/zipball/bfbac92300cfdca7606f19afb3f401431320e5ce",
+                "reference": "bfbac92300cfdca7606f19afb3f401431320e5ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.0.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "proj4php\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "Jason Judge",
+                    "email": "jason.judge@academe.co.uk",
+                    "homepage": "http://academe.co.uk",
+                    "role": "Developer"
+                },
+                {
+                    "name": "julien2512",
+                    "email": "moquet.julien@gmail.com",
+                    "homepage": "https://github.com/julien2512",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Nick Blackwell",
+                    "email": "nickblackwell82@gmail.com",
+                    "homepage": "https://people.ok.ubc.ca/nblackwe",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A PHP-Class for geographic coordinates transformation using proj4 definitions, thanks to a translation from Proj4JS",
+            "homepage": "https://github.com/proj4php/proj4php",
+            "keywords": [
+                "coordinates",
+                "geographic",
+                "proj4",
+                "proj4js"
+            ],
+            "time": "2017-05-03T20:02:09+00:00"
         },
         {
             "name": "psr/http-message",

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Classes\StatePlaneMapping;
+
 /*
 |--------------------------------------------------------------------------
 | Application Routes
@@ -21,3 +23,26 @@ $app->group(['prefix' => 'api/1.0'], function() use ($app) {
     $app->get('/rooms', 'RoomsController@handleRequest');
 });
 
+$app->get('calc', function() {
+	// known coordinates of MZ0000
+	//$old_lat = 34.237628419;
+	//$old_long = -118.530378707;
+
+	// plate coordinates (need to figure out how to reproduce these)
+	$plate_lat = 29.0040325363;
+	$plate_long = -124.51446532;
+
+	$dx = 6401365.22100000; // negate for known -> plate
+	$dy = 1909282.51400000; // negate for known -> plate
+
+	//dd(StatePlaneMapping::latLongRelative($old_lat, $old_long, $dx, $dy, StatePlaneMapping::UNITS_FEET));
+
+	$plate_coords = StatePlaneMapping::findPlateOriginFromCoordDistance(
+		34.237628419, -118.530378707, $dx, $dy, StatePlaneMapping::UNITS_FEET
+	);
+	dd($plate_coords);
+	$bldg_coords = StatePlaneMapping::findLatLongFromPlateDistance(
+		$plate_coords['lat'], $plate_coords['lon'], $dx, $dy, StatePlaneMapping::UNITS_FEET
+	);
+	dd($plate_coords, $bldg_coords);
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,7 +24,7 @@ $app->group(['prefix' => 'api/1.0'], function() use ($app) {
 });
 
 $app->get('calc', function() {
-	// known coordinates of MZ0000
+	// known coordinates of MZ0000 (this should be the result of the bldg_coords array)
 	$known_lat = 34.237628419;
 	$known_long = -118.530378707;
 
@@ -32,14 +32,15 @@ $app->get('calc', function() {
 	$plate_lat = 29.0040325363;
 	$plate_long = -124.51446532;
 
-	$dx = 6401365.22100000; // negate for known -> plate
-	$dy = 1909282.51400000; // negate for known -> plate
+	// X/Y distance from the plate coordinates
+	$dx = 6401365.22100000;
+	$dy = 1909282.51400000;
 
 	$plate_coords = StatePlaneMapping::findPlateOriginFromCoordDistance(
-		$known_lat, $known_long, $dx, $dy, StatePlaneMapping::UNITS_FEET
+		$known_lat, $known_long, $dy, StatePlaneMapping::UNITS_FEET
 	);
 	$bldg_coords = StatePlaneMapping::findLatLongFromPlateDistance(
-		$plate_coords['lat'], $plate_coords['lon'], $dx, $dy, StatePlaneMapping::UNITS_FEET
+		$plate_coords['lat'], $plate_coords['lon'], $dy, StatePlaneMapping::UNITS_FEET
 	);
 	dd($plate_coords, $bldg_coords);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,22 +25,19 @@ $app->group(['prefix' => 'api/1.0'], function() use ($app) {
 
 $app->get('calc', function() {
 	// known coordinates of MZ0000
-	//$old_lat = 34.237628419;
-	//$old_long = -118.530378707;
+	$known_lat = 34.237628419;
+	$known_long = -118.530378707;
 
-	// plate coordinates (need to figure out how to reproduce these)
+	// plate coordinates (as of Jan 5, 2018)
 	$plate_lat = 29.0040325363;
 	$plate_long = -124.51446532;
 
 	$dx = 6401365.22100000; // negate for known -> plate
 	$dy = 1909282.51400000; // negate for known -> plate
 
-	//dd(StatePlaneMapping::latLongRelative($old_lat, $old_long, $dx, $dy, StatePlaneMapping::UNITS_FEET));
-
 	$plate_coords = StatePlaneMapping::findPlateOriginFromCoordDistance(
-		34.237628419, -118.530378707, $dx, $dy, StatePlaneMapping::UNITS_FEET
+		$known_lat, $known_long, $dx, $dy, StatePlaneMapping::UNITS_FEET
 	);
-	dd($plate_coords);
 	$bldg_coords = StatePlaneMapping::findLatLongFromPlateDistance(
 		$plate_coords['lat'], $plate_coords['lon'], $dx, $dy, StatePlaneMapping::UNITS_FEET
 	);

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,23 +24,10 @@ $app->group(['prefix' => 'api/1.0'], function() use ($app) {
 });
 
 $app->get('calc', function() {
-	// known coordinates of MZ0000 (this should be the result of the bldg_coords array)
-	$known_lat = 34.237628419;
-	$known_long = -118.530378707;
-
-	// plate coordinates (as of Jan 5, 2018)
-	$plate_lat = 29.0040325363;
-	$plate_long = -124.51446532;
-
-	// X/Y distance from the plate coordinates
-	$dx = 6401365.22100000;
-	$dy = 1909282.51400000;
-
-	$plate_coords = StatePlaneMapping::findPlateOriginFromCoordDistance(
-		$known_lat, $known_long, $dy, StatePlaneMapping::UNITS_FEET
-	);
-	$bldg_coords = StatePlaneMapping::findLatLongFromPlateDistance(
-		$plate_coords['lat'], $plate_coords['lon'], $dy, StatePlaneMapping::UNITS_FEET
-	);
-	dd($plate_coords, $bldg_coords);
+	$map = new StatePlaneMapping();
+	$result = $map->convertPointToLatLong(
+		6401894.55600000,
+		1910627.60100000
+	); // X/Y for JD1600A (slightly more precise than Facilities)
+	dd($result);
 });


### PR DESCRIPTION
NOTE: Please make sure you run `composer install` to get the Proj4php package.

I left the `calc` route in so you can verify the precision of the library's calculations.

The web service now can perform its own calculations between zone 0405 (California Zone 5) in the State Plane Coordinate system and lat/long coordinates. It now also runs significantly faster since it is no longer relying on a third-party web service (and we won't get throttled since all the conversions take place in the library itself).

Enjoy!