### PR TITLE
Add the package to force HTTPS for Lumen

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -59,9 +59,10 @@ $app->singleton(
 |
 */
 
-// $app->middleware([
-//    App\Http\Middleware\ExampleMiddleware::class
-// ]);
+ $app->middleware([
+	// App\Http\Middleware\ExampleMiddleware::class,
+	CSUNMetaLab\LumenForceHttps\Http\Middleware\ForceHttps::class,
+]);
 
 // $app->routeMiddleware([
 //     'auth' => App\Http\Middleware\Authenticate::class,
@@ -84,6 +85,8 @@ $app->singleton(
 $app->configure('proxypass');
 $app->register(CSUNMetaLab\LumenProxyPass\Providers\ProxyPassServiceProvider::class);
 
+$app->configure('forcehttps');
+$app->register(CSUNMetaLab\LumenForceHttps\Providers\ForceHttpsServiceProvider::class);
 
 /*
 |--------------------------------------------------------------------------

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "vlucas/phpdotenv": "~2.2",
         "csun-metalab/lumen-proxypass": "^1.0",
         "guzzlehttp/guzzle": "~6.0",
-        "proj4php/proj4php": "^2.0"
+        "proj4php/proj4php": "^2.0",
+        "csun-metalab/lumen-force-https": "^1.0"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,50 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "a54b2f2833a03c137f77af9a5344a2c0",
+    "content-hash": "357117239dcaa9cc1f375345f10f5675",
     "packages": [
+        {
+            "name": "csun-metalab/lumen-force-https",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/csun-metalab/lumen-force-https.git",
+                "reference": "cc9fb59dfaedafea4c623f199a4d8e8f22d75e11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/csun-metalab/lumen-force-https/zipball/cc9fb59dfaedafea4c623f199a4d8e8f22d75e11",
+                "reference": "cc9fb59dfaedafea4c623f199a4d8e8f22d75e11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/LumenForceHttps/"
+                ],
+                "psr-0": {
+                    "CSUNMetaLab\\LumenForceHttps\\": "src/LumenForceHttps/"
+                },
+                "psr-4": {
+                    "CSUNMetaLab\\LumenForceHttps\\": "src/LumenForceHttps/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matthew Fritz",
+                    "email": "mattf@burbankparanormal.com"
+                }
+            ],
+            "description": "A small Composer package for Lumen that forces HTTPS in the URL via middleware",
+            "time": "2018-01-30T22:43:10+00:00"
+        },
         {
             "name": "csun-metalab/lumen-proxypass",
             "version": "1.0.4",

--- a/config/forcehttps.php
+++ b/config/forcehttps.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+
+	/*
+    |--------------------------------------------------------------------------
+    | Force HTTPS
+    |--------------------------------------------------------------------------
+    |
+    | Whether to force HTTPS on all URLs or not. Default is false.
+    |
+    */
+	'force_https' => env('FORCE_HTTPS', false),
+
+];


### PR DESCRIPTION
What it says. Run `composer install` first.

You can add `FORCE_HTTPS=true` to your `.env` file if your environment is configured for HTTPS traffic as well. The middleware will force everything properly then.

The package can be viewed at https://github.com/csun-metalab/lumen-force-https