### PR TITLE
Update missing lat/long coordinates for all rooms

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -40,3 +40,13 @@ function appendErrorDataToResponseHeader($headerArray){
     ];
 
 }
+
+/**
+ * @param $headerArray
+ * @return array
+ */
+function appendMessageDataToResponseHeader($headerArray, $message="success") {
+    return $headerArray += [
+        'message' => $message
+    ];
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
 $router->group(['prefix' => '1.0'], function() use ($router) {
+	$router->get('/rooms/sync', 'RoomsController@syncRoomCoordinates');
     $router->get('/rooms', 'RoomsController@handleRequest');
 });


### PR DESCRIPTION
Added functionality to update the lat and long values for all rooms where those values are missing.

This can be a route that is hit over cURL, for example, after a database sync.

The route is `/rooms/sync` but that can easily be changed based on how we decide to do the endpoint location.